### PR TITLE
config file fixes

### DIFF
--- a/templates/default/zoo.cfg.erb
+++ b/templates/default/zoo.cfg.erb
@@ -18,9 +18,9 @@ clientPort=<%= @node[:zookeeper][:client_port] %>
 
 <% if @servers.size > 1 -%>
   <% @servers.each_with_index do |server, i| %>
-server.<%= i %>=<%= server[:ipaddress] %>:<%= server[:zookeeper][:peer_port] %>:<%= server[:zookeeper][:leader_port] %>
+server.<%= i+1 %>=<%= server[:zookeeper][:ipaddress] %>:<%= server[:zookeeper][:peer_port] %>:<%= server[:zookeeper][:leader_port] %>
   <% end -%>
 <% else -%>
   <% server = @servers.first -%>
-server=<%= server[:ipaddress] %>:<%= server[:zookeeper][:peer_port] %>:<%= server[:zookeeper][:leader_port] %>
+server=<%= server[:zookeeper][:ipaddress] %>:<%= server[:zookeeper][:peer_port] %>:<%= server[:zookeeper][:leader_port] %>
 <% end -%>


### PR DESCRIPTION
`zoo.cfg` template has an error with `cluster_servers` configuration.

Current configuration:

```
# ....
server.0=:2888:3888
server.1=:2888:3888
server.2=:2888:3888
```

Expected configuration (https://zookeeper.apache.org/doc/r3.1.2/zookeeperStarted.html, section 'Running Replicated ZooKeeper'):

```
# ...
server.1=zoo1:2888:3888
server.2=zoo2:2888:3888
server.3=zoo3:2888:3888
```

role override_attributes:

```
"zookeper": {
           "cluster_servers": [
            {
                "name": "zoo1",
                "zookeeper":
                {
                    "ipaddress": "zoo1",
                    "fqdn": "zoo1.example.com",
                    "peer_port": 2888,
                    "leader_port": 3888
                }
            },
            {
                "name": "zoo2",
                "zookeeper":
                {
                    "ipaddress": "zoo2",
                    "fqdn": "zoo2.example.com",
                    "peer_port": 2888,
                    "leader_port": 3888
                }
            },
            {
                "name": "zoo3",
                "zookeeper":
                {
                    "ipaddress": "zoo3",
                    "fqdn": "zoo3.example.com",
                    "peer_port": 2888,
                    "leader_port": 3888
                }
            }
}
```
