### PR TITLE
myid fix

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,7 @@ default[:zookeeper][:cluster_name] = "default"
 # ZK defaults
 default[:zookeeper][:user] = "zookeeper"
 default[:zookeeper][:group] = "zookeeper"
-default[:zookeeper][:myid] = nil
+default[:zookeeper][:myid] = 0
 default[:zookeeper][:tick_time] = 2000
 default[:zookeeper][:init_limit] = 10
 default[:zookeeper][:sync_limit] = 5

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -124,7 +124,7 @@ directory node[:zookeeper][:data_dir] do
   mode 0755
 end
 
-if node[:zookeeper][:myid]
+if node[:zookeeper][:myid] != 0
   myid = node[:zookeeper][:myid]
 else
   myid = 1 + zk_servers.index { |n| n[:zookeeper][:ipaddress] == node[:ipaddress] } or 0


### PR DESCRIPTION
after the setup my `myid` file was empty. I found a couple of problems with it:
1. it should start with [1](http://stackoverflow.com/a/11498597/727938)
2. the same problem as in [pull request #3](https://github.com/geoforce/chef-zookeeper/pull/3): `n[:zookeper][:ipaddress]`
3. for some setups, you don't really know your external ip: e.g. vagrant boxes or aws instances. So I added an ability to mandatory set `node[:zookeper][:myid]` attribute.
